### PR TITLE
Mimic action_name behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2018-09-27
+### Added
+- A crude facsimile of `#action_name` to mimic the method of the same name found in ActionMailer.
+- Documentation in README for `#prevent_delivery?` usage.
+
 ## [0.1.2] - 2018-04-04
 ### Added
 - Support for Rails 5.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ or, less optimally:
 MyCoolMailer.welcome(user).deliver_now
 ```
 
+### Preventing Delivery
+
+In some mailers, you may wish to prevent delivery based on some business logic. For instance, if you offer email preferences to your users, you may want to check their preferences and prevent delivery if they've disabled email notifications.
+
+To add mailer-wide logic, simply define a `prevent_delivery?` method in your mailer:
+
+```ruby
+class MyCoolMailer < PostmarkMailer::Base
+  def welcome(user)
+    @user = user
+    mail(
+      to: @user.email,
+      template_id: 123_456,
+      template_model: {
+        first_name: @user.first_name
+      }
+    )
+  end
+
+  private
+
+  def prevent_delivery?
+    # Substitute the line below with your own logic
+    @user.all_emails_disabled?
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/postmark_mailer/base.rb
+++ b/lib/postmark_mailer/base.rb
@@ -1,15 +1,17 @@
 module PostmarkMailer
   class Base
+    attr_accessor :action_name
+
     class << self
       private
 
       def respond_to_missing?(method, *)
-        self.new.respond_to?(method) || super
+        new.respond_to?(method) || super
       end
 
       def method_missing(method, *args)
         if respond_to_missing?(method)
-          self.new.public_send(method, *args)
+          new(method.to_s).public_send(method, *args)
         else
           super
         end
@@ -18,14 +20,18 @@ module PostmarkMailer
 
     private
 
-      def mail(options)
-        if prevent_delivery?
-          NullDelivery.new(options)
-        else
-          MessageDelivery.new(options)
-        end
-      end
+    def initialize(method_name = nil)
+      @action_name = method_name
+    end
 
-      def prevent_delivery?; end
+    def mail(options)
+      if prevent_delivery?
+        NullDelivery.new(options)
+      else
+        MessageDelivery.new(options)
+      end
+    end
+
+    def prevent_delivery?; end
   end
 end

--- a/lib/postmark_mailer/version.rb
+++ b/lib/postmark_mailer/version.rb
@@ -1,3 +1,3 @@
 module PostmarkMailer
-  VERSION = "0.1.2"
+  VERSION = '0.1.3'.freeze
 end

--- a/postmark_mailer.gemspec
+++ b/postmark_mailer.gemspec
@@ -1,18 +1,18 @@
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "postmark_mailer/version"
+require 'postmark_mailer/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "postmark_mailer"
+  spec.name          = 'postmark_mailer'
   spec.version       = PostmarkMailer::VERSION
-  spec.authors       = ["John Ellis"]
-  spec.email         = ["john@scienceexchange.com"]
+  spec.authors       = ['John Ellis']
+  spec.email         = ['john@scienceexchange.com']
 
-  spec.summary       = %q{An ActionMailer replacement for those wishing to send emails using Postmark Templates.}
-  spec.description   = %q{Designed to mimic ActionMailer's familiar interface, this gem offers a way to send transactional emails that are rendered by Postmark's Templates feature and delivered via the Postmark API.}
-  spec.homepage      = "https://github.com/scienceexchange/postmark_mailer"
-  spec.license       = "MIT"
+  spec.summary       = 'An ActionMailer replacement for those wishing to send emails using Postmark Templates.'
+  spec.description   = "Designed to mimic ActionMailer's familiar interface, this gem offers a way to send transactional emails that are rendered by Postmark's Templates feature and delivered via the Postmark API."
+  spec.homepage      = 'https://github.com/scienceexchange/postmark_mailer'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -26,14 +26,14 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_dependency "activejob", ">= 4.2"
-  spec.add_dependency "postmark"
+  spec.add_dependency 'activejob', '>= 4.2'
+  spec.add_dependency 'postmark'
 end


### PR DESCRIPTION
Implements an `#action_name` method that mimics the method of the same name in ActionMailer.