### PR TITLE
[CDT-3478] Postmark gem update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,32 @@
 PATH
   remote: .
   specs:
-    postmark_mailer (0.1.0)
-      activejob (~> 4.2)
+    postmark_mailer (0.1.3)
+      activejob (>= 4.2)
       postmark
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activejob (4.2.10)
-      activesupport (= 4.2.10)
-      globalid (>= 0.3.0)
-    activesupport (4.2.10)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    concurrent-ruby (1.0.5)
+    activejob (6.1.3.1)
+      activesupport (= 6.1.3.1)
+      globalid (>= 0.3.6)
+    activesupport (6.1.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.3)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
-    i18n (0.9.1)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.1.0)
-    minitest (5.10.3)
-    postmark (1.10.0)
+    json (2.5.1)
+    minitest (5.14.4)
+    postmark (1.21.3)
       json
-      rake
     rake (10.4.2)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -41,9 +41,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.4)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -55,4 +55,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.17.2


### PR DESCRIPTION
1.10.0 used TLSv1 which they deprecated. 
postmark gem needs to be updated to 1.21.3.
